### PR TITLE
Allow users to change enabled collectors

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,6 @@ _windows_exporter_msi_remote_src: true
 
 # The directory on the remote host to where the windows exporter .msi installer will be downloaded or copied to
 _windows_exporter_download_dir: 'C:\Windows\Temp'
+
+# Features to enable in windows_exporter
+_windows_exporter_enabled_collectors: [ad,adfs,cache,cpu,cpu_info,cs,container,dfsr,dhcp,dns,fsrmquota,iis,logical_disk,logon,memory,msmq,mssql,netframework_clrexceptions,netframework_clrinterop,netframework_clrjit,netframework_clrloading,netframework_clrlocksandthreads,netframework_clrmemory,netframework_clrremoting,netframework_clrsecurity,net,os,process,remote_fx,service,tcp,time,vmware]

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
     retries: 5
     delay: 2
   - name: Install windows_exporter package
-    win_command: 'msiexec /i windows_exporter-{{ _windows_exporter_version }}-{{ _win_arch }}.msi ENABLED_COLLECTORS="ad,adfs,cache,cpu,cpu_info,cs,container,dfsr,dhcp,dns,fsrmquota,iis,logical_disk,logon,memory,msmq,mssql,netframework_clrexceptions,netframework_clrinterop,netframework_clrjit,netframework_clrloading,netframework_clrlocksandthreads,netframework_clrmemory,netframework_clrremoting,netframework_clrsecurity,net,os,process,remote_fx,service,tcp,time,vmware" TEXTFILE_DIR="C:\custom_metrics" LISTEN_PORT="9115"'
+    win_command: 'msiexec /i windows_exporter-{{ _windows_exporter_version }}-{{ _win_arch }}.msi ENABLED_COLLECTORS="{{ _windows_exporter_enabled_collectors | join(",") }}" TEXTFILE_DIR="C:\custom_metrics" LISTEN_PORT="9115"'
     args:
       chdir: "{{ _windows_exporter_download_dir }}"
     register: _installed_windows_exporter
@@ -30,7 +30,7 @@
       remote_src: "{{ _windows_exporter_msi_remote_src }}"
     register: __windows_exporter_copied
   - name: Install windows_exporter package
-    win_command: 'msiexec /i {{ __windows_exporter_copied.dest }} ENABLED_COLLECTORS="ad,adfs,cache,cpu,cpu_info,cs,container,dfsr,dhcp,dns,fsrmquota,iis,logical_disk,logon,memory,msmq,mssql,netframework_clrexceptions,netframework_clrinterop,netframework_clrjit,netframework_clrloading,netframework_clrlocksandthreads,netframework_clrmemory,netframework_clrremoting,netframework_clrsecurity,net,os,process,remote_fx,service,tcp,time,vmware" TEXTFILE_DIR="C:\custom_metrics" LISTEN_PORT="9115"'
+    win_command: 'msiexec /i {{ __windows_exporter_copied.dest }} ENABLED_COLLECTORS="{{ _windows_exporter_enabled_collectors | join(",") }}" TEXTFILE_DIR="C:\custom_metrics" LISTEN_PORT="9115"'
     register: _installed_windows_exporter
   - name: Remove installer package on successful install
     win_file:


### PR DESCRIPTION
In this role, many collectors are enabled by default and cannot be modified. I have introduced a new default variable, allowing users to either use the pre-specified collectors or customize them according to the options available at [Prometheus Community Windows Exporter](https://github.com/prometheus-community/windows_exporter).